### PR TITLE
Fix documentation package name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ CAUTION: This is financial software. The nature of the Brex API means that most 
 * A [library that implements PSR7](https://packagist.org/providers/psr/http-factory-implementation)
 
 ### Installation
-Install `nxsys/library.client-brex` with composer.
+Install `nxsys/library.clients-brex` with composer.
 
 ```bash
-composer require nxsys/library.client-brex
+composer require nxsys/library.clients-brex
 ```
 This library allows you to keep the http client library you may already
 be using in your application. It does this through [service discovery](https://docs.php-http.org/en/latest/discovery.html).
@@ -112,7 +112,7 @@ The following communication channels are open:
 - Chat: https://onx.zulipchat.com
 - Issues: https://github.com/NxSys/library.clients-brex/issues
 - Forum: https://github.com/NxSys/library.clients-brex/discussions
-<!-- - Wiki: https://nxsys.assembla.com/spaces/library.client-brex/wiki -->
+<!-- - Wiki: https://nxsys.assembla.com/spaces/library.clients-brex/wiki -->
 - Src: https://github.com/NxSys/library.clients-brex
 
 If you have any feedback, please reach out to us at onx@nxs.systems

--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,7 @@
 # Description:
 #  Build file for PHP SDK for Brex
 #
-# @link http://nxsys.org/spaces/library.client-brex
+# @link http://nxsys.org/spaces/library.clients-brex
 # @link https://onx.zulipchat.com Questions? Get project help!
 # @package NAME\SUB
 # @author ONX Group <onx@nxs.systems>
@@ -17,11 +17,11 @@
 #
 # @version $Revision: 1337 $
 # @copyright Copyright 2023 Nexus Systems Inc.
-# @license http://nxsys.org/spaces/library.client-brexlibrary.client-brex/wiki/license.html
+# @license http://nxsys.org/spaces/library.clients-brex/wiki/license.html
 # Please see the license.txt file or the url above for full copyright and
 # license terms.
 ============================================================================ -->
-<project name="library.client-brex" default="dist-full">
+<project name="library.clients-brex" default="dist-full">
 	<property name="dir.buildConfs"  value=".config" />
 	<property file="${dir.buildConfs}/build.properties" />
 	<fileset dir="." includesfile="${dir.buildConfs}/_dist-texts.txt" id="dist-texts"/>

--- a/docs/man/source/getting-started/getting-started.rst
+++ b/docs/man/source/getting-started/getting-started.rst
@@ -4,11 +4,11 @@ Getting Started
 
 Installation
 ------------
-Install `nxsys/library.client-brex <https://packagist.org/packages/nxsys/library.clients-brex>`_ with `Composer <https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos>`_.
+Install `nxsys/library.clients-brex <https://packagist.org/packages/nxsys/library.clients-brex>`_ with `Composer <https://getcomposer.org/doc/00-intro.md#installation-linux-unix-macos>`_.
 
 .. code-block::
 
-	composer require nxsys/library.client-brex
+        composer require nxsys/library.clients-brex
 
 And please don't forget
 

--- a/docs/man/source/index.rst
+++ b/docs/man/source/index.rst
@@ -53,7 +53,7 @@ The following communication channels are open:
 * Issues: https://github.com/NxSys/library.clients-brex/issues
 * Forum: https://github.com/NxSys/library.clients-brex/discussions
 
-.. <!-- - Wiki: https://nxsys.assembla.com/spaces/library.client-brex/wiki -->
+.. <!-- - Wiki: https://nxsys.assembla.com/spaces/library.clients-brex/wiki -->
 
 If you have any additional feedback, or commercial inquiries, please reach out to us at onx@nxs.systems.
 


### PR DESCRIPTION
## Summary
- fix composer install command to use `nxsys/library.clients-brex`
- update docs with correct package name
- correct build configuration links and project name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7ef3517c832580be90fc5559fa2c